### PR TITLE
Argparse cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package can:
 *Formatted* content (one per line) next to candump data:
 
 ```bash
-$ pretty_j1939.py --candata=true --format=true --link=true --transport=true example.candump.txt | head
+$ pretty_j1939.py --candata --format --link --transport example.candump.txt | head
 (1543509533.000838) can0 10FDA300#FFFF07FFFFFFFFFF ; {
                                                    ;     "DA": "All(255)",
                                                    ;     "PGN": "EEC6(64931)",
@@ -27,7 +27,7 @@ $ pretty_j1939.py --candata=true --format=true --link=true --transport=true exam
 Single-line contents next to candump data:
 
 ```bash
-$ pretty_j1939.py --candata=true --format=false --link=true --transport=true example.candump.txt | head
+$ pretty_j1939.py --candata --link --transport example.candump.txt | head
 (1543509533.000838) can0 10FDA300#FFFF07FFFFFFFFFF ; {"SA":"Engine #1(  0)","DA":"All(255)","PGN":"EEC6(64931)","Engine Variable Geometry Turbocharger Actuator #1":"2.8000000000000003 [%]"}
 (1543509533.000915) can0 18FEE000#FFFFFFFFB05C6800 ; {"SA":"Engine #1(  0)","DA":"All(255)","PGN":"VD(65248)","Total Vehicle Distance":"854934.0 [m]"}
 (1543509533.000991) can0 08FE6E0B#0000000000000000 ; {"SA":"Brakes - System Controller( 11)","DA":"All(255)","PGN":"HRW(65134)","Front Axle, Left Wheel Speed":"0.0 [kph]","Front axle, right wheel speed":"0.0 [kph]","Rear axle, left wheel speed":"0.0 [kph]","Rear axle, right wheel speed":"0.0 [kph]"}
@@ -43,7 +43,7 @@ $ pretty_j1939.py --candata=true --format=false --link=true --transport=true exa
 *Formatted* contents of the transport SPNs only.
 
 ```bash
-$ pretty_j1939.py --candata=false --format=true --link=false --transport=true example.candump.txt |head
+$ pretty_j1939.py --format --transport example.candump.txt | head
 {
     "Transport PGN": "AT1HI1(64920)",
     "Aftertreatment 1 Total Fuel Used": "227.5 [liters]",
@@ -76,27 +76,24 @@ The `pretty_j1939.py` script (and the `describer` in `pretty_j1939/parse.py` tha
 verbosity available when describing J1939 traffic in candump logs:
 
 ```bash
-usage: pretty_j1939.py [-h] [--candata [CANDATA]] [--pgn [PGN]] [--spn [SPN]]
-                       [--transport [TRANSPORT]] [--link [LINK]]
-                       [--include-na [INCLUDE_NA]] [--format [FORMAT]]
+usage: pretty_j1939.py [-h] [--candata] [--pgn] [--spn] [--transport] [--link]
+                       [--include-na] [--format]
                        candump
 
 pretty-printing J1939 candump logs
 
 positional arguments:
-  candump               candump log
+  candump       candump log
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --candata [CANDATA]   print input can data
-  --pgn [PGN]           print source/destination/type description
-  --spn [SPN]           print signals description
-  --transport [TRANSPORT]
-                        print details of transport-layer streams found
-  --link [LINK]         print details of link-layer frames found
-  --include-na [INCLUDE_NA]
-                        inlude not-available (0xff) SPN values
-  --format [FORMAT]     format each structure (otherwise single-line)
+  -h, --help    show this help message and exit
+  --candata     print input can data
+  --pgn         print source/destination/type description
+  --spn         print signals description
+  --transport   print details of transport-layer streams found
+  --link        print details of link-layer frames found
+  --include-na  include not-available (0xff) SPN values
+  --format      format each structure (otherwise single-line)
 ```
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package can:
 *Formatted* content (one per line) next to candump data:
 
 ```bash
-$ pretty_j1939.py --candata --format --link --transport example.candump.txt | head
+$ pretty_j1939.py --candata --format --transport example.candump.txt | head
 (1543509533.000838) can0 10FDA300#FFFF07FFFFFFFFFF ; {
                                                    ;     "DA": "All(255)",
                                                    ;     "PGN": "EEC6(64931)",
@@ -27,7 +27,7 @@ $ pretty_j1939.py --candata --format --link --transport example.candump.txt | he
 Single-line contents next to candump data:
 
 ```bash
-$ pretty_j1939.py --candata --link --transport example.candump.txt | head
+$ pretty_j1939.py --candata --transport example.candump.txt | head
 (1543509533.000838) can0 10FDA300#FFFF07FFFFFFFFFF ; {"SA":"Engine #1(  0)","DA":"All(255)","PGN":"EEC6(64931)","Engine Variable Geometry Turbocharger Actuator #1":"2.8000000000000003 [%]"}
 (1543509533.000915) can0 18FEE000#FFFFFFFFB05C6800 ; {"SA":"Engine #1(  0)","DA":"All(255)","PGN":"VD(65248)","Total Vehicle Distance":"854934.0 [m]"}
 (1543509533.000991) can0 08FE6E0B#0000000000000000 ; {"SA":"Brakes - System Controller( 11)","DA":"All(255)","PGN":"HRW(65134)","Front Axle, Left Wheel Speed":"0.0 [kph]","Front axle, right wheel speed":"0.0 [kph]","Rear axle, left wheel speed":"0.0 [kph]","Rear axle, right wheel speed":"0.0 [kph]"}
@@ -43,7 +43,7 @@ $ pretty_j1939.py --candata --link --transport example.candump.txt | head
 *Formatted* contents of the transport SPNs only.
 
 ```bash
-$ pretty_j1939.py --format --transport example.candump.txt | head
+$ pretty_j1939.py --format --no-link --transport example.candump.txt | head
 {
     "Transport PGN": "AT1HI1(64920)",
     "Aftertreatment 1 Total Fuel Used": "227.5 [liters]",
@@ -76,24 +76,31 @@ The `pretty_j1939.py` script (and the `describer` in `pretty_j1939/parse.py` tha
 verbosity available when describing J1939 traffic in candump logs:
 
 ```bash
-usage: pretty_j1939.py [-h] [--candata] [--pgn] [--spn] [--transport] [--link]
-                       [--include-na] [--format]
+usage: pretty_j1939.py [-h] [--candata] [--no-candata] [--pgn] [--no-pgn] [--spn] [--no-spn] [--transport] [--no-transport] [--link] [--no-link] [--include_na] [--no-include_na]
+                       [--format] [--no-format]
                        candump
 
 pretty-printing J1939 candump logs
 
 positional arguments:
-  candump       candump log
+  candump          candump log
 
 optional arguments:
-  -h, --help    show this help message and exit
-  --candata     print input can data
-  --pgn         print source/destination/type description
-  --spn         print signals description
-  --transport   print details of transport-layer streams found
-  --link        print details of link-layer frames found
-  --include-na  include not-available (0xff) SPN values
-  --format      format each structure (otherwise single-line)
+  -h, --help       show this help message and exit
+  --candata        print input can data
+  --no-candata     (default)
+  --pgn            (default) print source/destination/type description
+  --no-pgn
+  --spn            (default) print signals description
+  --no-spn
+  --transport      print details of transport-layer streams found
+  --no-transport   (default)
+  --link           (default) print details of link-layer frames found
+  --no-link
+  --include_na     include not-available (0xff) SPN values
+  --no-include_na  (default)
+  --format         format each structure (otherwise single-line)
+  --no-format      (default)
 ```
 
 ## Installing

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -11,13 +11,40 @@ pretty_j1939.parse.init_j1939db()
 
 parser = argparse.ArgumentParser(description='pretty-printing J1939 candump logs')
 parser.add_argument('candump', help='candump log')
-parser.add_argument('--candata', action='store_true', help='print input can data')
-parser.add_argument('--pgn', action='store_true', default=True, help='print source/destination/type description')
-parser.add_argument('--spn', action='store_true', default=True, help='print signals description')
-parser.add_argument('--transport', action='store_true', help='print details of transport-layer streams found')
-parser.add_argument('--link', action='store_true', default=True, help='print details of link-layer frames found')
-parser.add_argument('--include-na', action='store_true', help='include not-available (0xff) SPN values')
-parser.add_argument('--format', action='store_true', help='format each structure (otherwise single-line)')
+
+parser.add_argument('--candata',    dest='candata', action='store_true',  help='print input can data')
+parser.add_argument('--no-candata', dest='candata', action='store_false', help='(default)')
+parser.set_defaults(candata=False)
+
+parser.add_argument('--pgn',    dest='pgn', action='store_true', help='(default) print source/destination/type '
+                                                                      'description')
+parser.add_argument('--no-pgn', dest='pgn', action='store_false')
+parser.set_defaults(pgn=True)
+
+parser.add_argument('--spn',    dest='spn', action='store_true', help='(default) print signals description')
+parser.add_argument('--no-spn', dest='spn', action='store_false')
+parser.set_defaults(spn=True)
+
+parser.add_argument('--transport',    dest='transport', action='store_true',  help='print details of transport-layer '
+                                                                                   'streams found')
+parser.add_argument('--no-transport', dest='transport', action='store_false', help='(default)')
+parser.set_defaults(transport=False)
+
+parser.add_argument('--link',    dest='link', action='store_true', help='(default) print details of link-layer frames '
+                                                                        'found')
+parser.add_argument('--no-link', dest='link', action='store_false')
+parser.set_defaults(link=True)
+
+parser.add_argument('--include_na',    dest='include_na', action='store_true',  help='include not-available (0xff) SPN '
+                                                                                     'values')
+parser.add_argument('--no-include_na', dest='include_na', action='store_false', help='(default)')
+parser.set_defaults(include_na=False)
+
+parser.add_argument('--format',    dest='format', action='store_true',  help='format each structure (otherwise '
+                                                                             'single-line)')
+parser.add_argument('--no-format', dest='format', action='store_false', help='(default)')
+parser.set_defaults(format=False)
+
 args = parser.parse_args()
 
 describer = pretty_j1939.parse.get_describer(describe_pgns=args.pgn, describe_spns=args.spn,

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -29,15 +29,12 @@ if __name__ == '__main__':
         for candump_line in f.readlines():
             if candump_line == '\n':
                 continue
+
             try:
                 timestamp = float(candump_line.split(' ')[0].replace('(', '').replace(')', ''))
                 message_id = bitstring.ConstBitArray(hex=candump_line.split(' ')[2].split('#')[0])
                 message_data = bitstring.ConstBitArray(hex=candump_line.split(' ')[2].split('#')[1])
-
-            except IndexError:
-                print("Warning: error in line '%s'" % candump_line, file=sys.stderr)
-                continue
-            except ValueError:
+            except (IndexError, ValueError):
                 print("Warning: error in line '%s'" % candump_line, file=sys.stderr)
                 continue
 

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -31,9 +31,10 @@ if __name__ == '__main__':
                 continue
 
             try:
-                timestamp = float(candump_line.split(' ')[0].replace('(', '').replace(')', ''))
-                message_id = bitstring.ConstBitArray(hex=candump_line.split(' ')[2].split('#')[0])
-                message_data = bitstring.ConstBitArray(hex=candump_line.split(' ')[2].split('#')[1])
+                timestamp = float(candump_line.split()[0].lstrip('(').rstrip(')'))
+                message = candump_line.split()[2]
+                message_id = bitstring.ConstBitArray(hex=message.split('#')[0])
+                message_data = bitstring.ConstBitArray(hex=message.split('#')[1])
             except (IndexError, ValueError):
                 print("Warning: error in line '%s'" % candump_line, file=sys.stderr)
                 continue

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -16,7 +16,7 @@ parser.add_argument('--pgn', action='store_true', default=True, help='print sour
 parser.add_argument('--spn', action='store_true', default=True, help='print signals description')
 parser.add_argument('--transport', action='store_true', help='print details of transport-layer streams found')
 parser.add_argument('--link', action='store_true', default=True, help='print details of link-layer frames found')
-parser.add_argument('--include-na', action='store_true', help='inlude not-available (0xff) SPN values')
+parser.add_argument('--include-na', action='store_true', help='include not-available (0xff) SPN values')
 parser.add_argument('--format', action='store_true', help='format each structure (otherwise single-line)')
 args = parser.parse_args()
 

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -47,8 +47,6 @@ if __name__ == '__main__':
                 json_description = str(json.dumps(description, separators=(',', ':')))
             if len(description) > 0:
                 desc_line = desc_line + json_description
-            else:
-                desc_line = ''
 
             if args.candata:
                 can_line = candump_line.rstrip() + " ; "

--- a/pretty_j1939.py
+++ b/pretty_j1939.py
@@ -9,27 +9,15 @@ import pretty_j1939.parse
 pretty_j1939.parse.init_j1939db()
 
 
-def str2bool(v):
-    return v.lower() in ("yes", "true", "t", "1")
-
-
 parser = argparse.ArgumentParser(description='pretty-printing J1939 candump logs')
 parser.add_argument('candump', help='candump log')
-parser.add_argument('--candata', type=str2bool, const=True, default=False, nargs='?',
-                    help='print input can data')
-parser.add_argument('--pgn',     type=str2bool, const=True, default=True, nargs='?',
-                    help='print source/destination/type description')
-parser.add_argument('--spn',     type=str2bool, const=True, default=True, nargs='?',
-                    help='print signals description')
-parser.add_argument('--transport', type=str2bool, const=True, default=True, nargs='?',
-                    help='print details of transport-layer streams found')
-parser.add_argument('--link', type=str2bool, const=True, default=True, nargs='?',
-                    help='print details of link-layer frames found')
-parser.add_argument('--include-na', type=str2bool, const=True, default=False, nargs='?',
-                    help='inlude not-available (0xff) SPN values')
-parser.add_argument('--format',  type=str2bool, const=True, default=False, nargs='?',
-                    help='format each structure (otherwise single-line)')
-
+parser.add_argument('--candata', action='store_true', help='print input can data')
+parser.add_argument('--pgn', action='store_true', default=True, help='print source/destination/type description')
+parser.add_argument('--spn', action='store_true', default=True, help='print signals description')
+parser.add_argument('--transport', action='store_true', help='print details of transport-layer streams found')
+parser.add_argument('--link', action='store_true', default=True, help='print details of link-layer frames found')
+parser.add_argument('--include-na', action='store_true', help='inlude not-available (0xff) SPN values')
+parser.add_argument('--format', action='store_true', help='format each structure (otherwise single-line)')
 args = parser.parse_args()
 
 describer = pretty_j1939.parse.get_describer(describe_pgns=args.pgn, describe_spns=args.spn,


### PR DESCRIPTION
Cleaned up arguments by removing the custom type definition and using the built-in 'store_true' argparse action. Now you just need to specify the flag to enable it and should not append `=true` to any of the arguments.

The flags for link-layer details, PGN and SPN descriptions default to true and thus they never really need to be specified. Perhaps these should be revamped to be negated instead (i.e. 'store_false' action)?