### PR TITLE
fix issue #25 by using append the right way...

### DIFF
--- a/pretty_j1939/describe.py
+++ b/pretty_j1939/describe.py
@@ -339,8 +339,9 @@ def get_spn_cut_bytes(spn_start, spn_length, message_data_bitstring, is_complete
     if len(spn_start) > 1:
         lsplit = int(spn_start[1] / 8) * 8 - spn_start[0]
         rsplit = spn_length - lsplit
-        cut_data = bitstring.BitArray(message_data_bitstring[spn_start[0]:spn_start[0] + lsplit]).append(
-            message_data_bitstring[spn_start[1]:spn_start[1] + rsplit])
+        b = bitstring.BitArray(message_data_bitstring[spn_start[0]:spn_start[0] + lsplit])
+        b.append(message_data_bitstring[spn_start[1]:spn_start[1] + rsplit])
+        cut_data = b
     return cut_data
 
 


### PR DESCRIPTION
now correctly emits the front axle speed testcase from issue #25 

```
#  python3 pretty_j1939.py --candata --real-time --format --da-json tmp/J1939DA_201910.json tmp/issue25.log
(1621774359.366587) can0 14FEBF80#1010010203040506 ; {
                                                   ;     "PGN": "EBC2(65215)",
                                                   ;     "DA": "All(255)",
                                                   ;     "SA": "Unknown(128)",
                                                   ;     "Front Axle Speed": "16.0625 [km/h]",
                                                   ;     "Relative Speed; Front Axle, Left Wheel": "-7.75 [km/h]",
                                                   ;     "Relative Speed; Front Axle, Right Wheel": "-7.6875 [km/h]",
                                                   ;     "Relative Speed; Rear Axle #1, Left Wheel": "-7.625 [km/h]",
                                                   ;     "Relative Speed; Rear Axle #1, Right Wheel": "-7.5625 [km/h]",
                                                   ;     "Relative Speed; Rear Axle #2, Left Wheel": "-7.5 [km/h]",
                                                   ;     "Relative Speed; Rear Axle #2, Right Wheel": "-7.4375 [km/h]"
                                                   ; }
```